### PR TITLE
Fix a small typo in investigative action

### DIFF
--- a/_chapters/fascist_track_powers.md
+++ b/_chapters/fascist_track_powers.md
@@ -9,8 +9,8 @@ When a Fascist policy is played, the President may get a special power to enact.
 ### Investigations
 When there is an investigation and the investigatee is called to be a Liberal, the probability of the investigatee being Liberal is slightly higher. The four possibilities are:
 
-- Liberal President, Liberal Chancellor: Should always result in a liberal call
-- FL: The Fascist President may accuse the Chancellor in order to create chaos, or they might call a Liberal to maintain cover
+- Liberal President, Liberal investigatee: Should always result in a liberal call
+- FL: The Fascist President may accuse the investigatee in order to create chaos, or they might call a Liberal to maintain cover
 - LF: Should always result in a fascist call
   - See the [Experimental Strategy: The Slow Burn](#the-slow-burn)
 - FF: Most of the time the president will call liberal, but they might sometimes call fascist to cause chaos.


### PR DESCRIPTION
The chancellor is not involved in the investigative action, and their role does not matter for the outcome; instead, the text should refer to the investigatee.